### PR TITLE
override suit css for wider Selector fields needed when selecting PCA…

### DIFF
--- a/EquiTrack/templates/admin/base_site.html
+++ b/EquiTrack/templates/admin/base_site.html
@@ -86,6 +86,14 @@
         padding-right: 40px;
 
     }
+
+   /* ==========================================================================
+      Django Suit Overrides
+   ========================================================================== */
+
+    .form-horizontal .control-group .controls .selector .selector-available, .form-horizontal .control-group .controls .selector .selector-chosen {
+        max-width: 400px;
+    }
     </style>
 
 {% endblock %}


### PR DESCRIPTION
…s for trips.
![image](https://cloud.githubusercontent.com/assets/11025927/9193636/875a1722-401d-11e5-898e-5c5b9ccd67ab.png)
